### PR TITLE
Dtype and WRITEABLE fixes

### DIFF
--- a/src/adios2py/file.py
+++ b/src/adios2py/file.py
@@ -180,9 +180,9 @@ class File(Group):
             # if data isn't writeable, for some reason, DefineVariable throws an unhelpful ValueError that mentions the type of the data (generally np.ndarray).
             try:
                 data.setflags(write=True)
-            except:
-                msg = "Data needs to be writeable (even though it won't be modified). Unable to set it to writeable here (possibly because it's a view of an un-writeable array). Try calling `setflags`"
-                raise ValueError(msg)
+            except Exception as exc:
+                msg = "Data needs to be flagged as writeable (even though it won't be modified). Unable to set it to writeable here (possibly because it's a view of an un-writeable array)."
+                raise ValueError(msg) from exc
 
         var = self.io.InquireVariable(name)
         if not var:

--- a/src/adios2py/file.py
+++ b/src/adios2py/file.py
@@ -176,6 +176,14 @@ class File(Group):
         if data.ndim != 0:
             data = np.ascontiguousarray(data)
 
+        if not data.flags["WRITEABLE"]:
+            # if data isn't writeable, for some reason, DefineVariable throws an unhelpful ValueError that mentions the type of the data (generally np.ndarray).
+            try:
+                data.setflags(write=True)
+            except:
+                msg = "Data needs to be writeable (even though it won't be modified). Unable to set it to writeable here (possibly because it's a view of an un-writeable array). Try calling `setflags`"
+                raise ValueError(msg)
+
         var = self.io.InquireVariable(name)
         if not var:
             var = self.io.DefineVariable(

--- a/src/adios2py/group.py
+++ b/src/adios2py/group.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator, Mapping
 from typing import TYPE_CHECKING
 
 import adios2  # type: ignore[import-untyped]
+import numpy as np
 
 from adios2py.array_proxy import ArrayProxy
 from adios2py.attrs_proxy import AttrsProxy
@@ -35,7 +36,7 @@ class Group(Mapping[str, ArrayProxy]):
         if not var:
             msg = f"Variable {name} not found."
             raise KeyError(msg)
-        dtype = adios2.type_adios_to_numpy(var.Type())
+        dtype = np.dtype(adios2.type_adios_to_numpy(var.Type()))
         if self._step is None:  # represent all steps as additional dimension
             shape = (self._file._steps(), *var.Shape())
             return ArrayProxy(

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -190,6 +190,19 @@ def test_write_test1_file(tmp_path):
     check_test1_file_lowlevel(filename)
 
 
+def test_write_frozen_array(tmp_path):
+    filename = tmp_path / "test1.bp"
+    with adios2py.File(filename, "w") as file:  # noqa: SIM117
+        with file.steps.next() as step:
+            frozen_arr = np.arange(5.0)
+            frozen_arr.setflags(write=False)
+
+            with pytest.raises(
+                ValueError, match="Data needs to be flagged as writeable"
+            ):
+                step._file._write("frozen", frozen_arr.view())
+
+
 # Tests for a file with multiple steps
 
 


### PR DESCRIPTION
Fix the strange new error in [xarray-adios2](https://github.com/unh-hpc/xarray-adios2/issues/17) and [pscpy](https://github.com/psc-code/pscpy/issues/39). It seems that adios2 changed to require np ndarrays have the WRITEABLE flag set.